### PR TITLE
Strap yourselves in...

### DIFF
--- a/aaf-gumboot.gemspec
+++ b/aaf-gumboot.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'factory_girl'
   spec.add_development_dependency 'faker'

--- a/lib/gumboot/strap.rb
+++ b/lib/gumboot/strap.rb
@@ -1,3 +1,6 @@
+require 'yaml'
+require 'active_support/core_ext/hash/deep_merge'
+
 module Gumboot
   module Strap
     def client

--- a/lib/gumboot/strap.rb
+++ b/lib/gumboot/strap.rb
@@ -1,0 +1,69 @@
+module Gumboot
+  module Strap
+    def client
+      file = File.expand_path('~/.my.cnf')
+      @client ||= Mysql2::Client.new(default_file: file,
+                                     default_group: 'client',
+                                     host: '127.0.0.1')
+    end
+
+    def ensure_activerecord_databases(environments)
+      environments.each do |env|
+        message "Preparing #{env} database"
+
+        db = ActiveRecord::Base.configurations[env]
+
+        ensure_database(db)
+        ensure_database_user(db)
+      end
+    end
+
+    def ensure_database(db)
+      adapter, database = db.values_at(*%w(adapter database))
+      fail('Only supports mysql2 adapter') unless adapter == 'mysql2'
+
+      puts "Ensuring database `#{database}` exists"
+      client.query("CREATE DATABASE IF NOT EXISTS `#{database}`")
+    end
+
+    def ensure_database_user(db)
+      adapter, database, username, password =
+        db.values_at(*%w(adapter database username password))
+
+      fail('Only supports mysql2 adapter') unless adapter == 'mysql2'
+
+      puts "Ensuring access to `#{database}` for #{username} user is granted"
+      client.query("GRANT ALL PRIVILEGES ON `#{database}`.* " \
+                   "TO '#{client.escape(username)}'@'localhost' " \
+                   "IDENTIFIED BY '#{client.escape(password)}'")
+    end
+
+    def maintain_activerecord_schema
+      message 'Loading database schema'
+
+      if ActiveRecord::Base.connection.execute('SHOW TABLES').count.zero?
+        puts 'No tables exist yet, loading schema'
+        system 'rake db:schema:load'
+      end
+
+      puts 'Running migrations'
+      system 'rake db:migrate'
+    end
+
+    def clean_logs
+      message 'Removing old tempfiles'
+      system 'rm -f log/*'
+    end
+
+    def clean_tempfiles
+      message 'Removing old tempfiles'
+      system 'rm -rf tmp/cache'
+    end
+
+    private
+
+    def message(msg)
+      puts "\n== #{msg} =="
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/api_controller.rb
+++ b/spec/dummy/app/controllers/api/api_controller.rb
@@ -44,8 +44,8 @@ module API
 
       x509_dn_hash['CN'] || fail(Unauthorized, 'Subject CN invalid')
 
-      rescue OpenSSL::X509::NameError
-        raise(Unauthorized, 'Subject DN invalid')
+    rescue OpenSSL::X509::NameError
+      raise(Unauthorized, 'Subject DN invalid')
     end
 
     def check_access!(action)

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/spec/lib/gumboot/strap_spec.rb
+++ b/spec/lib/gumboot/strap_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+require 'mysql2'
+require 'gumboot/strap'
+
+RSpec.describe Gumboot::Strap do
+  let(:client) { spy(Mysql2::Client) }
+  let(:kernel) { double(Kernel) }
+
+  let(:db_configs) do
+    {
+      'one' => {
+        'adapter' => 'mysql2',
+        'database' => 'one_db',
+        'username' => 'one_user',
+        'password' => 'one_password'
+      },
+      'two' => {
+        'adapter' => 'mysql2',
+        'database' => 'two_db',
+        'username' => 'two_user',
+        'password' => 'two_password'
+      }
+    }
+  end
+
+  before do
+    opts = {
+      default_file: "#{ENV['HOME']}/.my.cnf",
+      default_group: 'client',
+      host: '127.0.0.1'
+    }
+
+    allow(Mysql2::Client).to receive(:new).with(opts).and_return(client)
+    allow(client).to receive(:escape) { |x| x }
+  end
+
+  let(:klass) do
+    Class.new do
+      include Gumboot::Strap
+      attr_reader :kernel
+
+      def initialize(kernel)
+        @kernel = kernel
+      end
+
+      def puts(*); end
+
+      def system(*args)
+        kernel.system(*args)
+      end
+    end
+  end
+
+  subject { klass.new(kernel) }
+
+  context '#ensure_activerecord_databases' do
+    before do
+      allow(ActiveRecord::Base).to receive(:configurations)
+        .and_return(db_configs)
+    end
+
+    it 'creates the databases' do
+      expect(client).to receive(:query)
+        .with('CREATE DATABASE IF NOT EXISTS `one_db`').once
+      expect(client).to receive(:query)
+        .with('CREATE DATABASE IF NOT EXISTS `two_db`').once
+
+      allow(client).to receive(:query).with(match(/^GRANT ALL.*/))
+
+      subject.ensure_activerecord_databases(db_configs.keys)
+    end
+
+    it 'sets permissions for database users' do
+      expect(client).to receive(:query)
+        .with("GRANT ALL PRIVILEGES ON `one_db`.* TO 'one_user'@'localhost' " \
+              "IDENTIFIED BY 'one_password'").once
+      expect(client).to receive(:query)
+        .with("GRANT ALL PRIVILEGES ON `two_db`.* TO 'two_user'@'localhost' " \
+              "IDENTIFIED BY 'two_password'").once
+
+      allow(client).to receive(:query).with(match(/^CREATE DATABASE.*/))
+
+      subject.ensure_activerecord_databases(db_configs.keys)
+    end
+  end
+
+  context '#ensure_database' do
+    let(:opts) { { 'adapter' => 'mysql2', 'database' => 'test_db' } }
+
+    it 'creates the database' do
+      expect(client).to receive(:query)
+        .with('CREATE DATABASE IF NOT EXISTS `test_db`').once
+
+      subject.ensure_database(opts)
+    end
+
+    it 'fails when adapter is not mysql2' do
+      expect { subject.ensure_database(opts.merge('adapter' => 'xyz')) }
+        .to raise_error(/Only supports mysql2 adapter/)
+    end
+  end
+
+  context '#ensure_database_user' do
+    let(:opts) do
+      { 'adapter' => 'mysql2', 'database' => 'test_db',
+        'username' => 'test_user', 'password' => 'test_password' }
+    end
+
+    it 'sets permission for the database user' do
+      expect(client).to receive(:query)
+        .with('GRANT ALL PRIVILEGES ON `test_db`.* TO ' \
+              "'test_user'@'localhost' IDENTIFIED BY 'test_password'").once
+
+      subject.ensure_database_user(opts)
+    end
+
+    it 'fails when adapter is not mysql2' do
+      expect { subject.ensure_database_user(opts.merge('adapter' => 'xyz')) }
+        .to raise_error(/Only supports mysql2 adapter/)
+    end
+  end
+
+  context '#maintain_activerecord_schema' do
+    let(:tables) { [] }
+
+    before do
+      expect(ActiveRecord::Base).to receive_message_chain(:connection, :execute)
+        .with('SHOW TABLES').and_return(tables)
+    end
+
+    context 'when a database already exists' do
+      let(:tables) { %w(schema_migrations) }
+
+      it 'runs the migrations' do
+        expect(subject.kernel).to receive(:system).with('rake db:migrate')
+        subject.maintain_activerecord_schema
+      end
+    end
+
+    it 'loads the schema before running migrations' do
+      expect(subject.kernel).to receive(:system).with('rake db:schema:load')
+      expect(subject.kernel).to receive(:system).with('rake db:migrate')
+      subject.maintain_activerecord_schema
+    end
+  end
+
+  context '#clean_logs' do
+    it 'removes the log files' do
+      expect(subject.kernel).to receive(:system).with('rm -f log/*')
+      subject.clean_logs
+    end
+  end
+
+  context '#clean_tempfiles' do
+    it 'removes the temp files' do
+      expect(subject.kernel).to receive(:system).with('rm -rf tmp/cache')
+      subject.clean_tempfiles
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'rspec/rails'
 require 'simplecov'
 
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment.rb',  __FILE__)
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 FactoryGirl.find_definitions
 


### PR DESCRIPTION
![](https://www.wellies.com.au/media/catalog/product/cache/1/image/645x645/9df78eab33525d08d6e5fb8d27136e95/p/e/peta-strap-web.jpg)

Adds some helpers to Gumboot to facilitate bootstrapping a project.

The new `Gumboot::Strap` module is expected to be consumed from `bin/setup` scripts in our projects, and will reduce the number of steps required to get a project running in development mode.

Here's my current working example:

```ruby
#!/usr/bin/env ruby

Dir.chdir File.expand_path('..', File.dirname(__FILE__))

puts '== Installing dependencies =='
system 'gem install bundler --conservative'
system 'bundle check || bundle install'

require 'bundler/setup'
require 'gumboot/strap'

include Gumboot::Strap

puts "\n== Installing configuration files =="
link_global_configuration %w(rapidconnect.yml)
update_local_configuration %w(reporting_service.yml)

puts "\n== Loading Rails environment =="
require_relative '../config/environment'

ensure_activerecord_databases(%w(test development))
maintain_activerecord_schema
clean_logs
clean_tempfiles
```