### PR TITLE
Correctly handle the X509-DN header passed from Apache when no client certificate was provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,8 +483,7 @@ module API
     def x509_cn
       # Verified DN pushed by nginx following successful client SSL verification
       # nginx is always going to do a better job of terminating SSL then we can
-      x509_dn = request.headers['HTTP_X509_DN'].try(:force_encoding, 'UTF-8')
-      fail(Unauthorized, 'Subject DN') unless x509_dn
+      fail(Unauthorized, 'Subject DN') if x509_dn.nil?
 
       x509_dn_parsed = OpenSSL::X509::Name.parse(x509_dn)
       x509_dn_hash = Hash[x509_dn_parsed.to_a
@@ -492,8 +491,13 @@ module API
 
       x509_dn_hash['CN'] || fail(Unauthorized, 'Subject CN invalid')
 
-      rescue OpenSSL::X509::NameError
-        raise(Unauthorized, 'Subject DN invalid')
+    rescue OpenSSL::X509::NameError
+      raise(Unauthorized, 'Subject DN invalid')
+    end
+
+    def x509_dn
+      x509_dn = request.headers['HTTP_X509_DN'].try(:force_encoding, 'UTF-8')
+      x509_dn == '(null)' ? nil : x509_dn
     end
 
     def check_access!(action)
@@ -517,7 +521,6 @@ module API
     end
   end
 end
-
 ```
 
 ##### RSpec shared examples

--- a/lib/gumboot/shared_examples/api_controller.rb
+++ b/lib/gumboot/shared_examples/api_controller.rb
@@ -33,6 +33,23 @@ RSpec.shared_examples 'API base controller' do
         end
       end
 
+      context 'x509 header set to "(null)"' do
+        before do
+          request.env['HTTP_X509_DN'] = '(null)'
+          get :an_action
+        end
+
+        it { is_expected.to have_http_status(:unauthorized) }
+        context 'json within response' do
+          it 'has a message' do
+            expect(json['message']).to eq('SSL client failure.')
+          end
+          it 'has an error' do
+            expect(json['error']).to eq('Subject DN')
+          end
+        end
+      end
+
       context 'invalid x509 header set by nginx' do
         before do
           request.env['HTTP_X509_DN'] = "Z=#{Faker::Lorem.word}"

--- a/spec/dummy/app/controllers/api/api_controller.rb
+++ b/spec/dummy/app/controllers/api/api_controller.rb
@@ -35,8 +35,7 @@ module API
     def x509_cn
       # Verified DN pushed by nginx following successful client SSL verification
       # nginx is always going to do a better job of terminating SSL then we can
-      x509_dn = request.headers['HTTP_X509_DN'].try(:force_encoding, 'UTF-8')
-      fail(Unauthorized, 'Subject DN') unless x509_dn
+      fail(Unauthorized, 'Subject DN') if x509_dn.nil?
 
       x509_dn_parsed = OpenSSL::X509::Name.parse(x509_dn)
       x509_dn_hash = Hash[x509_dn_parsed.to_a
@@ -46,6 +45,11 @@ module API
 
     rescue OpenSSL::X509::NameError
       raise(Unauthorized, 'Subject DN invalid')
+    end
+
+    def x509_dn
+      x509_dn = request.headers['HTTP_X509_DN'].try(:force_encoding, 'UTF-8')
+      x509_dn == '(null)' ? nil : x509_dn
     end
 
     def check_access!(action)


### PR DESCRIPTION
Per #11 