### PR TITLE
Add more stringent checks for collation/encoding

### DIFF
--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -1,16 +1,11 @@
 RSpec.shared_examples 'Database Schema' do
   context 'AAF shared implementation' do
-    RSpec::Matchers.define :have_collation do |expected|
+    RSpec::Matchers.define :have_collation do |expected, name|
       match { |actual| actual[:Collation] == expected }
 
       failure_message do |actual|
-        if actual[:Field]
-          format('expected field `%<Field>s` to use collation `%<expected>s`,' \
-                 ' but was `%<Collation>s`', actual.merge(expected: expected))
-        else
-          format('expected table `%<Name>s` to use collation `%<expected>s`, ' \
-                 'but was `%<Collation>s`', actual.merge(expected: expected))
-        end
+        "expected #{name} to use collation #{expected}, but was " \
+          "#{actual[:Collation]}"
       end
     end
 
@@ -30,12 +25,15 @@ RSpec.shared_examples 'Database Schema' do
 
     it 'has the correct collation' do
       query('SHOW TABLE STATUS').each do |table|
-        next if table[:Name] == 'schema_migrations'
-        expect(table).to have_collation('utf8_bin')
+        table_name = table[:Name]
+        next if table_name == 'schema_migrations'
+        expect(table).to have_collation('utf8_bin', "`#{table_name}`")
 
         query("SHOW FULL COLUMNS FROM #{table[:Name]}").each do |column|
           next unless column[:Collation]
-          expect(column).to have_collation('utf8_bin')
+          expect(column)
+            .to have_collation('utf8_bin',
+                               " `#{table_name}`.`#{column[:Field]}`")
         end
       end
     end

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -16,6 +16,10 @@ RSpec.shared_examples 'Database Schema' do
 
     before { expect(connection).to be_a(Mysql2::Client) }
 
+    def query(sql)
+      connection.query(sql, as: :hash, symbolize_keys: true)
+    end
+
     it 'has the correct encoding set for the connection' do
       expect(connection.query_options).to include(encoding: 'utf8')
     end
@@ -25,15 +29,11 @@ RSpec.shared_examples 'Database Schema' do
     end
 
     it 'has the correct collation' do
-      tables = connection.query('SHOW TABLE STATUS',
-                                as: :hash, symbolize_keys: true)
-      tables.each do |table|
+      query('SHOW TABLE STATUS').each do |table|
         next if table[:Name] == 'schema_migrations'
         expect(table).to have_collation('utf8_bin')
 
-        columns = connection.query("SHOW FULL COLUMNS FROM #{table[:Name]}",
-                                   as: :hash, symbolize_keys: true)
-        columns.each do |column|
+        query("SHOW FULL COLUMNS FROM #{table[:Name]}").each do |column|
           next unless column[:Collation]
           expect(column).to have_collation('utf8_bin')
         end

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -11,6 +11,10 @@ RSpec.shared_examples 'Database Schema' do
 
     before { expect(connection).to be_a(Mysql2::Client) }
 
+    it 'has the correct collation set for the connection' do
+      expect(connection.query_options).to include(collation: 'utf8_bin')
+    end
+
     it 'has the correct collation' do
       result = connection.query('SHOW TABLE STATUS',
                                 as: :hash, symbolize_keys: true)

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -11,6 +11,10 @@ RSpec.shared_examples 'Database Schema' do
 
     before { expect(connection).to be_a(Mysql2::Client) }
 
+    it 'has the correct encoding set for the connection' do
+      expect(connection.query_options).to include(encoding: 'utf8')
+    end
+
     it 'has the correct collation set for the connection' do
       expect(connection.query_options).to include(collation: 'utf8_bin')
     end


### PR DESCRIPTION
#23 didn't quite cover it, so a few things needed tweaking:

* Require database connection to have the correct encoding and collation set
* Require columns to be migrated properly, too
* Document these things