### PR TITLE
Add `install_dist_template` method to Strap

### DIFF
--- a/lib/gumboot/strap.rb
+++ b/lib/gumboot/strap.rb
@@ -84,6 +84,18 @@ module Gumboot
       end
     end
 
+    def install_dist_template(files)
+      files.each do |file|
+        src = "config/#{file}.dist"
+        dest = "config/#{file}"
+
+        raise("Missing dist config file: #{src}") unless File.exist?(src)
+
+        next if File.exist?(dest)
+        FileUtils.copy(src, dest)
+      end
+    end
+
     private
 
     def message(msg)

--- a/spec/lib/gumboot/strap_spec.rb
+++ b/spec/lib/gumboot/strap_spec.rb
@@ -283,4 +283,40 @@ RSpec.describe Gumboot::Strap do
       end
     end
   end
+
+  describe '#install_dist_template' do
+    let(:filename) { Faker::Lorem.words(2).join('.') }
+    let(:src) { "config/#{filename}.dist" }
+    let(:dest) { "config/#{filename}" }
+
+    def run
+      subject.install_dist_template([filename])
+    end
+
+    before do
+      allow(File).to receive(:exist?).with(src).and_return(true)
+    end
+
+    context 'when the target file exists' do
+      before do
+        allow(File).to receive(:exist?).with(dest).and_return(true)
+      end
+
+      it 'does not copy the file' do
+        expect(FileUtils).not_to receive(:copy)
+        run
+      end
+    end
+
+    context 'when the target file does not exist' do
+      before do
+        allow(File).to receive(:exist?).with(dest).and_return(false)
+      end
+
+      it 'copies the file' do
+        expect(FileUtils).to receive(:copy).with(src, dest)
+        run
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows apps to install dist templates which are *not* YAML files, as part of their `bin/setup` script.