### PR TITLE
Add uniqueness and formatting constraints to x509 for api_subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cases this will be xyz-service, you should drop the `-service`.
 
 e.g. For bigboot-service, you'd use `bigboot_app`
 
-Database name: `xyz_#{env}` - where xyz represents the name of your application. 
+Database name: `xyz_#{env}` - where xyz represents the name of your application.
 In most cases this will be xyz-service, you should drop the `-service`.
 
 e.g. For bigboot-service, you'd use `bigboot_development` for development.
@@ -148,11 +148,11 @@ production:
 
 ### UTF8 and binary collation
 
-The example config above will ensure your database connection is using 
+The example config above will ensure your database connection is using
 the `utf8` character set, and `utf8_bin` collation which is required for all
-AAF applications. 
+AAF applications.
 
-However you *MUST* also create a migration which ensures the correct setting 
+However you *MUST* also create a migration which ensures the correct setting
 is applied at the database level:
 
 ```ruby
@@ -305,7 +305,7 @@ end
 ```
 
 ### API Subject
-An API Subject is an extension of the Subject concept reserved specifically for Subjects that utilise x509 client certificate verification to make requests to the applications RESTful API endpoints.
+An API Subject is an extension of the Subject concept reserved specifically for Subjects that utilise x509 client certificate verification to make requests to the applications RESTful API endpoints. x509_cn client certificates **MUST** be unique.
 
 #### Active Model
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ class APISubject < ActiveRecord::Base
   has_many :roles, through: :api_subject_roles
 
   valhammer
+  validates :x509_cn, format: { with: /\A[\w-]+\z/ }
 
   def permissions
     # This could be extended to gather permissions from
@@ -353,6 +354,7 @@ class APISubject < Sequel::Model
   def validate
     validates_presence [:x509_cn, :description,
                         :contact_name, :contact_mail, :enabled]
+    validates_format /\A[\w-]+\z/, :x509_cn
   end
 end
 ```

--- a/lib/gumboot/shared_examples/api_subjects.rb
+++ b/lib/gumboot/shared_examples/api_subjects.rb
@@ -13,6 +13,10 @@ RSpec.shared_examples 'API Subjects' do
       subject.x509_cn = nil
       expect(subject).not_to be_valid
     end
+    it 'is invalid if an x509 value is not unique' do
+      create(:api_subject, x509_cn: subject.x509_cn)
+      expect(subject).not_to be_valid
+    end
     it 'is invalid without a description' do
       subject.description = nil
       expect(subject).not_to be_valid

--- a/lib/gumboot/shared_examples/api_subjects.rb
+++ b/lib/gumboot/shared_examples/api_subjects.rb
@@ -13,6 +13,13 @@ RSpec.shared_examples 'API Subjects' do
       subject.x509_cn = nil
       expect(subject).not_to be_valid
     end
+    it 'is invalid if an x509 value is not in the correct format' do
+      subject.x509_cn += '%^%&*'
+      expect(subject).not_to be_valid
+    end
+    it 'is valid if an x509 value is in the correct format' do
+      expect(subject).to be_valid
+    end
     it 'is invalid if an x509 value is not unique' do
       create(:api_subject, x509_cn: subject.x509_cn)
       expect(subject).not_to be_valid

--- a/spec/dummy/app/models/api_subject.rb
+++ b/spec/dummy/app/models/api_subject.rb
@@ -7,6 +7,7 @@ class APISubject < ActiveRecord::Base
   has_many :roles, through: :api_subject_roles
 
   valhammer
+  validates :x509_cn, format: { with: /\A[\w-]+\z/ }
 
   def permissions
     # This could be extended to gather permissions from

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :description, null: false
     t.boolean :enabled, null: false
     t.timestamps null: false
+    t.index [:x509_cn], unique: true
   end
 
   create_table :api_subject_roles do |t|


### PR DESCRIPTION
Added documentation to README conveying new uniqueness requirement and
added new spec to verify that this constraint applies to resolve issue raised in [PR for downstream app](https://github.com/ausaccessfed/validator-service/pull/5).

Closes #8