### PR TITLE
Further refine core Gumboot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 Edit `spec/spec_helper.rb` and add
 
 ``` ruby
-require simplecov
+require 'simplecov'
 ```
 
 ## Git Ignore

--- a/README.md
+++ b/README.md
@@ -138,6 +138,80 @@ Execute:
 
     $ bundle
 
+## Guard
+Gumboot projects make use of Guard, Rubocop, RSpec and Brakeman.
+
+To get this all up and running you should execute:
+
+	$ bundle exec guard init
+	
+The result will be a reasonably complete `Guardfile`. As described earlier you can remove the default comments that are generated and also references to the Turnip project which we don't utilise.
+
+### RSpec
+Add a RSpec config file `.rspec`:
+
+```
+--color
+--require spec_helper
+--format documentation
+```
+
+### Rubocop
+Add a Rubocop config file `.rubocop.yml`:
+
+```
+AllCops:
+  TargetRubyVersion: 2.3
+  Exclude:
+    - db/schema.rb
+
+Rails:
+  Enabled: true
+
+Rails/Output:
+  Exclude:
+    - db/seeds.rb
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Exclude:
+    - db/migrate/*.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - db/migrate/*.rb
+```
+
+### Simplecov
+Add a simplecov config file `.simplecov`:
+
+```
+SimpleCov.start('rails') do
+  minimum_coverage 100
+end
+```
+
+## Git Ignore
+This needs to be customised per application but be sure it excludes **all** local config files, keys, certificates and anything else containing secrets. For example:
+
+```
+# TODO this is application specific
+config/xyz_service.yml
+
+config/rapidconnect.yml
+config/api-client.*
+config/event_encryption_key.pem
+spec/examples.txt
+
+coverage
+tmp
+log
+vendor
+.DS_Store
+```
+
 ## Acronyms
 Ensure 'API' is an acronym within your application:
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 Edit `spec/spec_helper.rb` and add
 
 ``` ruby
-require simplecove
+require simplecov
 ```
 
 ## Git Ignore

--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ To get this all up and running you should execute:
 The result will be a reasonably complete `Guardfile`. As described earlier you can remove the default comments that are generated and also references to the Turnip project which we don't utilise.
 
 ### RSpec
-Add a RSpec config file `.rspec`:
+Execute:
+
+	$ bundle exec rails generate rspec:install
+	
+Modify the generated RSpec config file as follows `.rspec`:
 
 ```
 --color
@@ -191,6 +195,12 @@ Add a simplecov config file `.simplecov`:
 SimpleCov.start('rails') do
   minimum_coverage 100
 end
+```
+
+Edit `spec/spec_helper.rb` and add
+
+``` ruby
+require simplecove
 ```
 
 ## Git Ignore

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Before you get started you should ensure your development machine has the follow
 		
 	Access [https://rapid.test.aaf.edu.au](https://rapid.test.aaf.edu.au) and register using your secret created above and the callback URL of `http://localhost:8080/auth/jwt`
 
-	As a result of successful registration you can add your secret and the URL the registration provided to you in the format below to your `rapidconnect.yml` file.
+	Upon successful registration you cannot simply use the URL Rapid Connect provides by team. Request one of the team change your registration to be of the type `AU Research`. They can then provide you the appropriate URL to enter below.
+	
+	Edit your `rapidconnect.yml` to contains:
 
 	``` ruby
 	---
 	url: 'https://rapid.test.aaf.edu.au/jwt/authnrequest/.....'
-	secret: '<you must generate this>'
+	secret: '<you generated this>'
 	issuer: 'https://rapid.test.aaf.edu.au'
 	audience: 'http://localhost:8080'
 	```
@@ -250,12 +252,12 @@ Execute:
 
     $ bundle
 
-#### Authentication Reciever
-To utilise Rapid Connect your application will require a reciever class
+#### Authentication Receiver
+To utilise Rapid Connect your application will require a receiver class
 which will receive the validated claim from Rapid Connect and establish a
 session for the authenticated subject.
 
-As an initial step our reciever class will be a no-op. You'll implement the reciever, in full, later in this document.
+As an initial step our receiver class will be a no-op. You'll implement the receiver, in full, later in this document.
 
 Create `lib/authentication.rb`:
 
@@ -282,11 +284,11 @@ module Authentication
 
     def subject(_env, attrs)
     end
-	end
+  end
 end
 ```
 
-#### Configure Reciever
+#### Configure receiver
 Add the following to `config/application.rb`:
 
 ``` ruby
@@ -751,7 +753,7 @@ end
 ```
 
 ## Authentication and Identity (2 of 2)
-You should now follow the documention for [https://github.com/ausaccessfed/rapid-rack](https://github.com/ausaccessfed/rapid-rack) or [https://github.com/ausaccessfed/shib-rack](https://github.com/ausaccessfed/shib-rack) depending on how your application is handling authentication and identity to complete your reciever implementation.
+You should now follow the documention for [https://github.com/ausaccessfed/rapid-rack](https://github.com/ausaccessfed/rapid-rack) or [https://github.com/ausaccessfed/shib-rack](https://github.com/ausaccessfed/shib-rack) depending on how your application is handling authentication and identity to complete your receiver implementation.
 
 ## Access Control
 

--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,32 @@ RSpec.describe APIConstraints do
 end
 ```
 
-# Event Handling
+## Event Handling
 
 **TODO** - Publishing and consuming events from AAF SQS.
+
+## Continuous Integration
+
+**TODO**
+
+``` ruby
+# frozen_string_literal: true
+begin
+  require 'rubocop/rake_task'
+  require 'brakeman'
+rescue LoadError
+  :production
+end
+
+require File.expand_path('../config/application', __FILE__)
+
+Rails.application.load_tasks
+
+RuboCop::RakeTask.new if defined? RuboCop
+
+task :brakeman do
+  Brakeman.run app_path: '.', print_report: true, exit_on_warn: true
+end
+
+task default: [:rubocop, :spec, :brakeman]
+```


### PR DESCRIPTION
This adds documentation about:

* Expected local development environment
* Defining a setup script (strap)
* How rapid-rack and shib-rack should be added to GB projects

This removes:

* References to the view layer