### PR TITLE
Fix SELECT N+1 issue in subject permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ class Subject < ActiveRecord::Base
   def permissions
     # This could be extended to gather permissions from
     # other data sources providing input to subject identity
-    roles.flat_map { |role| role.permissions.map(&:value) }
+    roles.joins(:permissions).pluck('permissions.value')
   end
 
   def functioning?

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ class APISubject < ActiveRecord::Base
   def permissions
     # This could be extended to gather permissions from
     # other data sources providing input to api_subject identity
-    roles.flat_map { |role| role.permissions.map(&:value) }
+    roles.joins(:permissions).pluck('permissions.value')
   end
 
   def functioning?

--- a/spec/dummy/app/models/api_subject.rb
+++ b/spec/dummy/app/models/api_subject.rb
@@ -12,7 +12,7 @@ class APISubject < ActiveRecord::Base
   def permissions
     # This could be extended to gather permissions from
     # other data sources providing input to api_subject identity
-    roles.flat_map { |role| role.permissions.map(&:value) }
+    roles.joins(:permissions).pluck('permissions.value')
   end
 
   def functioning?

--- a/spec/dummy/app/models/subject.rb
+++ b/spec/dummy/app/models/subject.rb
@@ -9,7 +9,7 @@ class Subject < ActiveRecord::Base
   def permissions
     # This could be extended to gather permissions from
     # other data sources providing input to subject identity
-    roles.flat_map { |role| role.permissions.map(&:value) }
+    roles.joins(:permissions).pluck('permissions.value')
   end
 
   def functioning?


### PR DESCRIPTION
Bullet identified a minor inefficiency with how we retrieve permissions strings, particular in the case of a subject with 2+ roles. This ensures it'll be fixed consistently across all applications, as the new model code is adopted.