### PR TITLE
Update .rubocop.yml to suit the latest Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in aaf-gumboot.gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 guard :bundler do
   watch('Gemfile')
   watch(/^.+\.gemspec/)

--- a/README.md
+++ b/README.md
@@ -170,44 +170,8 @@ Modify the generated RSpec config file as follows `.rspec`:
 Add a Rubocop config file `.rubocop.yml`:
 
 ```
-AllCops:
-  TargetRubyVersion: 2.3
-  Exclude:
-    - db/schema.rb
-
-Rails:
-  Enabled: true
-
-Rails/Output:
-  Exclude:
-    - db/seeds.rb
-
-Rails/NotNullColumn:
-  Enabled: false
-
-Rails/ReversibleMigration:
-  Enabled: false
-
-Rails/SkipsModelValidations:
-  Exclude:
-    - db/migrate/*.rb
-
-Style/Documentation:
-  Enabled: false
-
-Metrics/MethodLength:
-  Exclude:
-    - db/migrate/*.rb
-
-Metrics/AbcSize:
-  Exclude:
-    - db/migrate/*.rb
-
-Metrics/BlockLength:
-  Exclude:
-    - config/**/*.rb
-    - spec/**/*.rb
-    - db/**/*.rb
+inherit_gem:
+  aaf-gumboot: aaf-rubocop.yml
 ```
 
 ### Simplecov

--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ Rails/Output:
   Exclude:
     - db/seeds.rb
 
+Rails/NotNullColumn:
+  Enabled: false
+
+Rails/ReversibleMigration:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - db/migrate/*.rb
+
 Style/Documentation:
   Enabled: false
 
@@ -192,6 +202,12 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Exclude:
     - db/migrate/*.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - config/**/*.rb
+    - spec/**/*.rb
+    - db/**/*.rb
 ```
 
 ### Simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -6,4 +7,4 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: [:spec, :rubocop]
+task default: %i(spec rubocop)

--- a/aaf-gumboot.gemspec
+++ b/aaf-gumboot.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gumboot/version'

--- a/aaf-rubocop.yml
+++ b/aaf-rubocop.yml
@@ -11,6 +11,16 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/NotNullColumn:
+  Enabled: false
+
+Rails/ReversibleMigration:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - db/migrate/*.rb
+
 Rails/Output:
   Exclude:
     - db/seeds.rb

--- a/lib/aaf-gumboot.rb
+++ b/lib/aaf-gumboot.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 require 'gumboot'

--- a/lib/gumboot.rb
+++ b/lib/gumboot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gumboot
   # Your code goes here...
 end

--- a/lib/gumboot/shared_examples/anonymous_controller.rb
+++ b/lib/gumboot/shared_examples/anonymous_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Anon controller' do
   controller(described_class) do
     def an_action

--- a/lib/gumboot/shared_examples/api_constraints.rb
+++ b/lib/gumboot/shared_examples/api_constraints.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'API constraints' do
   context 'AAF shared implementation' do
     context '#matches?' do

--- a/lib/gumboot/shared_examples/api_controller.rb
+++ b/lib/gumboot/shared_examples/api_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: false
+
 require 'gumboot/shared_examples/anonymous_controller'
 
 RSpec.shared_examples 'API base controller' do

--- a/lib/gumboot/shared_examples/api_subjects.rb
+++ b/lib/gumboot/shared_examples/api_subjects.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'API Subjects' do
   context 'AAF shared implementation' do
     subject { build :api_subject }

--- a/lib/gumboot/shared_examples/application_controller.rb
+++ b/lib/gumboot/shared_examples/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'gumboot/shared_examples/anonymous_controller'
 
 RSpec.shared_examples 'Application controller' do

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Database Schema' do
   context 'AAF shared implementation' do
     RSpec::Matchers.define :have_collation do |expected, name|

--- a/lib/gumboot/shared_examples/foreign_keys.rb
+++ b/lib/gumboot/shared_examples/foreign_keys.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Gumboot Foreign Keys' do
   RSpec.shared_examples 'gumboot fk' do
     let(:conn) do

--- a/lib/gumboot/shared_examples/permissions.rb
+++ b/lib/gumboot/shared_examples/permissions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Permissions' do
   context 'AAF shared implementation' do
     subject { build :permission }

--- a/lib/gumboot/shared_examples/roles.rb
+++ b/lib/gumboot/shared_examples/roles.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Roles' do
   context 'AAF shared implementation' do
     subject { build :role }

--- a/lib/gumboot/shared_examples/subjects.rb
+++ b/lib/gumboot/shared_examples/subjects.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Subjects' do
   context 'AAF shared implementation' do
     subject { build :subject }

--- a/lib/gumboot/strap.rb
+++ b/lib/gumboot/strap.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'yaml'
 require 'active_support/core_ext/hash/deep_merge'
 

--- a/lib/gumboot/version.rb
+++ b/lib/gumboot/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gumboot
   VERSION = '1.0.0-alpha.2'
 end

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks

--- a/spec/dummy/app/controllers/api/api_controller.rb
+++ b/spec/dummy/app/controllers/api/api_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'openssl'
 
 module API
@@ -46,7 +47,6 @@ module API
       ]
 
       x509_dn_hash['CN'] || raise(Unauthorized, 'Subject CN invalid')
-
     rescue OpenSSL::X509::NameError
       raise(Unauthorized, 'Subject DN invalid')
     end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   Forbidden = Class.new(StandardError)
   private_constant :Forbidden

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/spec/dummy/app/models/api_subject.rb
+++ b/spec/dummy/app/models/api_subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'accession'
 
 class APISubject < ActiveRecord::Base

--- a/spec/dummy/app/models/api_subject_role.rb
+++ b/spec/dummy/app/models/api_subject_role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class APISubjectRole < ActiveRecord::Base
   belongs_to :api_subject
   belongs_to :role

--- a/spec/dummy/app/models/permission.rb
+++ b/spec/dummy/app/models/permission.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Permission < ActiveRecord::Base
   belongs_to :role
 

--- a/spec/dummy/app/models/role.rb
+++ b/spec/dummy/app/models/role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Role < ActiveRecord::Base
   has_many :api_subject_roles
   has_many :api_subjects, through: :api_subject_roles

--- a/spec/dummy/app/models/subject.rb
+++ b/spec/dummy/app/models/subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Subject < ActiveRecord::Base
   include Accession::Principal
 

--- a/spec/dummy/app/models/subject_role.rb
+++ b/spec/dummy/app/models/subject_role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SubjectRole < ActiveRecord::Base
   belongs_to :subject
   belongs_to :role

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = false
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = true
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = true
 

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy/config/initializers/cookies_serializer.rb
+++ b/spec/dummy/config/initializers/cookies_serializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/spec/dummy/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_session'

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -1,5 +1,6 @@
 
 # frozen_string_literal: true
+
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 Rails.application.routes.draw do
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ActiveRecord::Schema.define(version: 0) do
   create_table :roles do |t|
     t.string :name, null: false
@@ -9,7 +10,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :value, null: false
     t.belongs_to :role, null: false
     t.timestamps null: false
-    t.index [:role_id, :value], unique: true
+    t.index %i(role_id value), unique: true
   end
 
   create_table :api_subjects do |t|

--- a/spec/dummy/lib/api_constraints.rb
+++ b/spec/dummy/lib/api_constraints.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class APIConstraints
   def initialize(version:, default: false)
     @version = version

--- a/spec/factories/api_subjects.rb
+++ b/spec/factories/api_subjects.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :api_subject, class: API::APISubject do
     x509_cn { Faker::Lorem.word }

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :permission do
     association :role

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :role, class: 'Role' do
     name { Faker::Lorem.word }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :subject do
     name { Faker::Name.name }

--- a/spec/gumboot/api_constraints_spec.rb
+++ b/spec/gumboot/api_constraints_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/api_constraints'

--- a/spec/gumboot/api_controller_spec.rb
+++ b/spec/gumboot/api_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/api_controller'

--- a/spec/gumboot/api_subjects_spec.rb
+++ b/spec/gumboot/api_subjects_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/api_subjects'

--- a/spec/gumboot/application_controller_spec.rb
+++ b/spec/gumboot/application_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/application_controller'

--- a/spec/gumboot/foreign_keys_spec.rb
+++ b/spec/gumboot/foreign_keys_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/foreign_keys'

--- a/spec/gumboot/permissions_spec.rb
+++ b/spec/gumboot/permissions_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/permissions'

--- a/spec/gumboot/roles_spec.rb
+++ b/spec/gumboot/roles_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/roles'

--- a/spec/gumboot/subjects_spec.rb
+++ b/spec/gumboot/subjects_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'gumboot/shared_examples/subjects'

--- a/spec/lib/gumboot/strap_spec.rb
+++ b/spec/lib/gumboot/strap_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'mysql2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubygems'
 require 'factory_girl'
 require 'rails/all'


### PR DESCRIPTION
A few issues with the default cops need to be addressed:

- The `NotNullColumn` cop requires migrations to be changed retrospectively, but is at odds with common sense anyway. The only way to force a value to be provided by the app is to have it not nullable   and lacking a default value
- `ReversibleMigration` can't always be done
- `SkipsModelValidations` isn't valid in a migration which needs to `update_all` or similar, so we skip it. The conventional wisdom is that migrations **must not** rely on the model classes from the
  application because they may change over time (but migrations shouldn't!)
- The `BlockLength` limitation is nonsense in:
    - App configuration files
    - Database schema, migrations and seeds
    - RSpec examples