### PR TITLE
Collation exemptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ require 'gumboot/shared_examples/database_schema'
 RSpec.describe 'Database Schema' do
   let(:connection) { ActiveRecord::Base.connection.raw_connection }
   # Use the following (as an example) for column based exemptions
-  let(:collation_exemptions) { table_name: %i[column_name]] }
+  let(:collation_exemptions) { table_name: %i[column_name] }
 
   include_context 'Database Schema'
 end

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ require 'gumboot/shared_examples/database_schema'
 RSpec.describe 'Database Schema' do
   let(:connection) { ActiveRecord::Base.connection.raw_connection }
   # Use the following (as an example) for column based exemptions
-  let(:collation_exemptions) { table_name: %i[column_name] }
+  let(:collation_exemptions) { { table_name: %i[column_name] } }
 
   include_context 'Database Schema'
 end

--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ require 'gumboot/shared_examples/database_schema'
 
 RSpec.describe 'Database Schema' do
   let(:connection) { ActiveRecord::Base.connection.raw_connection }
+  # Use the following (as an example) for column based exemptions
+  let(:collation_exemptions) { [%i[table_name column_name]] }
 
   include_context 'Database Schema'
 end

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ require 'gumboot/shared_examples/database_schema'
 RSpec.describe 'Database Schema' do
   let(:connection) { ActiveRecord::Base.connection.raw_connection }
   # Use the following (as an example) for column based exemptions
-  let(:collation_exemptions) { [%i[table_name column_name]] }
+  let(:collation_exemptions) { table_name: %i[column_name]] }
 
   include_context 'Database Schema'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: %i(spec rubocop)
+task default: %i[spec rubocop]

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples 'Database Schema' do
     end
 
     it 'has the correct collation' do
-      exemptions = collation_exemptions ? collation_exemptions : []
+      exemptions = defined?(collation_exemptions) ? collation_exemptions : []
 
       db_collation = query('SHOW VARIABLES LIKE "collation_database"')
                      .first[:Value]

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -35,7 +35,7 @@ RSpec.shared_examples 'Database Schema' do
         next if table_name == 'schema_migrations'
         expect(table).to have_collation('utf8_bin', "`#{table_name}`")
 
-        query("SHOW FULL COLUMNS FROM #{table[:Name]}").each do |column|
+        query("SHOW FULL COLUMNS FROM #{table_name}").each do |column|
           next unless column[:Collation]
           expect(column)
             .to have_collation('utf8_bin',

--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -39,9 +39,11 @@ RSpec.shared_examples 'Database Schema' do
 
         query("SHOW FULL COLUMNS FROM #{table_name}").each do |column|
           next unless column[:Collation]
-          next if exemptions.any? do |(except_table, except_column)|
+          next if exemptions.any? do |except_table, except_columns|
                     except_table == table_name.to_sym &&
-                    except_column == column[:Field].to_sym
+                    except_columns.any? do |except_column|
+                      except_column == column[:Field].to_sym
+                    end
                   end
           expect(column)
             .to have_collation('utf8_bin',

--- a/spec/dummy/app/models/api_subject.rb
+++ b/spec/dummy/app/models/api_subject.rb
@@ -2,7 +2,7 @@
 
 require 'accession'
 
-class APISubject < ActiveRecord::Base
+class APISubject < ApplicationRecord
   include Accession::Principal
 
   has_many :api_subject_roles

--- a/spec/dummy/app/models/api_subject_role.rb
+++ b/spec/dummy/app/models/api_subject_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class APISubjectRole < ActiveRecord::Base
+class APISubjectRole < ApplicationRecord
   belongs_to :api_subject
   belongs_to :role
 

--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/spec/dummy/app/models/permission.rb
+++ b/spec/dummy/app/models/permission.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Permission < ActiveRecord::Base
+class Permission < ApplicationRecord
   belongs_to :role
 
   valhammer

--- a/spec/dummy/app/models/role.rb
+++ b/spec/dummy/app/models/role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   has_many :api_subject_roles
   has_many :api_subjects, through: :api_subject_roles
 

--- a/spec/dummy/app/models/subject.rb
+++ b/spec/dummy/app/models/subject.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Subject < ActiveRecord::Base
+class Subject < ApplicationRecord
   include Accession::Principal
 
   has_many :subject_roles

--- a/spec/dummy/app/models/subject_role.rb
+++ b/spec/dummy/app/models/subject_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubjectRole < ActiveRecord::Base
+class SubjectRole < ApplicationRecord
   belongs_to :subject
   belongs_to :role
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :value, null: false
     t.belongs_to :role, null: false
     t.timestamps null: false
-    t.index %i(role_id value), unique: true
+    t.index %i[role_id value], unique: true
   end
 
   create_table :api_subjects do |t|

--- a/spec/lib/gumboot/strap_spec.rb
+++ b/spec/lib/gumboot/strap_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Gumboot::Strap do
     end
 
     context 'when a database already exists' do
-      let(:tables) { %w(schema_migrations) }
+      let(:tables) { %w[schema_migrations] }
 
       it 'runs the migrations' do
         expect(subject.kernel).to receive(:system).with('rake db:migrate')
@@ -181,19 +181,19 @@ RSpec.describe Gumboot::Strap do
       expect(FileUtils).to receive(:ln_s).with("#{base}/b", 'config/b')
       expect(FileUtils).to receive(:ln_s).with("#{base}/c", 'config/c')
 
-      subject.link_global_configuration(%w(a b c))
+      subject.link_global_configuration(%w[a b c])
     end
 
     it 'skips an existing file' do
       allow(File).to receive(:exist?).and_return(true)
       expect(FileUtils).not_to receive(:ln_s)
 
-      subject.link_global_configuration(%w(a))
+      subject.link_global_configuration(%w[a])
     end
 
     it 'raises an error for a missing file' do
       allow(File).to receive(:exist?).and_return(false)
-      expect { subject.link_global_configuration(%w(a)) }
+      expect { subject.link_global_configuration(%w[a]) }
         .to raise_error(/Missing global config file/)
     end
   end


### PR DESCRIPTION
This allows certain columns to be defined as not needing strict
utf8_bin collation, and for gumboot to ignore them when checking
schemas.