### PR TITLE
Fix the rake tasks after the Ruby 2.7 update

### DIFF
--- a/aaf-gumboot.gemspec
+++ b/aaf-gumboot.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'rails-controller-testing'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec-rails'
+  spec.add_development_dependency 'rspec-rails', '~> 4.0.0.beta'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rails'
   spec.add_development_dependency 'simplecov'

--- a/spec/dummy/.rubocop.yml
+++ b/spec/dummy/.rubocop.yml
@@ -4,3 +4,7 @@ inherit_from:
 AllCops:
   Exclude:
     - db/schema.rb
+
+Rails/ApplicationController:
+  Exclude:
+    - app/controllers/api/api_controller.rb


### PR DESCRIPTION
There were a couple of errors causing the rake task to fail when running this in a Ruby 2.7 environment. Mainly the error described here: http://jessehouse.com/blog/2019/06/19/actionview-template-error-wrong-number-of-arguments-given-2/