### PR TITLE
Set configuration for new rails cops

### DIFF
--- a/aaf-rubocop.yml
+++ b/aaf-rubocop.yml
@@ -14,6 +14,15 @@ Rails/NotNullColumn:
 Rails/ReversibleMigration:
   Enabled: false
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Rails/ApplicationController:
   Exclude:
     - app/controllers/api/api_controller.rb


### PR DESCRIPTION
3 new cops have been introduced in Rubocop 0.80.0, these do not come with a default value, all have been turned on as a good style guide to follow.

see https://rubocop.readthedocs.io/en/latest/cops_style/ for what they do.