### PR TITLE
Don't require subjects to have a mail attribute

### DIFF
--- a/lib/gumboot/shared_examples/subjects.rb
+++ b/lib/gumboot/shared_examples/subjects.rb
@@ -15,10 +15,6 @@ RSpec.shared_examples 'Subjects' do
       subject.name = nil
       expect(subject).not_to be_valid
     end
-    it 'is invalid without mail' do
-      subject.mail = nil
-      expect(subject).not_to be_valid
-    end
     it 'is invalid without an enabled state' do
       subject.enabled = nil
       expect(subject).not_to be_valid


### PR DESCRIPTION
The mail attribute isn't necessary in all places and is blocking a
change to validator-service. Drop it from the shared suite.

See https://github.com/ausaccessfed/validator-service/issues/234 for context