### PR TITLE
fix: YAML.safe_load call arguments error in ruby 3.1

### DIFF
--- a/lib/gumboot/strap.rb
+++ b/lib/gumboot/strap.rb
@@ -122,7 +122,7 @@ module Gumboot
     end
 
     def safe_load(yaml)
-      YAML.safe_load(yaml, [Symbol])
+      YAML.safe_load(yaml, permitted_classes: [Symbol])
     end
 
     def merge_config(src, dest)

--- a/lib/gumboot/version.rb
+++ b/lib/gumboot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gumboot
-  VERSION = '2.5.1'
+  VERSION = '2.6.0'
 end


### PR DESCRIPTION
Hi team,

This PRs resolves [#72]

Ref link: 
https://ruby-doc.org/stdlib-3.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load