### PR TITLE
add utf8mb4 as an acceptable mysql encoding

### DIFF
--- a/lib/gumboot/shared_examples/database_schema.rb
+++ b/lib/gumboot/shared_examples/database_schema.rb
@@ -17,12 +17,19 @@ RSpec.shared_examples 'Database Schema' do
       connection.query(sql, as: :hash, symbolize_keys: true)
     end
 
+    encoding_options = {
+      'utf8mb4' => 'utf8mb4_bin',
+      'utf8' => 'utf8_bin'
+    }
+
     it 'has the correct encoding set for the connection' do
-      expect(connection.query_options).to include(encoding: 'utf8')
+      expect(encoding_options.keys).to include connection.query_options[:encoding]
     end
 
     it 'has the correct collation set for the connection' do
-      expect(connection.query_options).to include(collation: 'utf8_bin')
+      collation = encoding_options[connection.query_options[:encoding]]
+      expect(collation).not_to eq nil
+      expect(connection.query_options).to include(collation:)
     end
 
     it 'has the correct collation' do

--- a/lib/gumboot/version.rb
+++ b/lib/gumboot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gumboot
-  VERSION = '2.6.3'
+  VERSION = '2.6.4'
 end


### PR DESCRIPTION
`utf8` in mysql 5.7 uses `utf8mb3` which is deprecated. This allow schema check for `utf8mb4` to pass